### PR TITLE
use snmpversion 1 - v2c don't work on MFC-5490CN

### DIFF
--- a/brother/__init__.py
+++ b/brother/__init__.py
@@ -115,7 +115,7 @@ class Brother:  # pylint:disable=too-many-instance-attributes
         try:
             request_args = [
                 snmp_engine,
-                hlapi.CommunityData("public", mpModel=1),
+                hlapi.CommunityData("public", mpModel=0),
                 hlapi.UdpTransportTarget((self._host, self._port)),
                 hlapi.ContextData(),
             ]


### PR DESCRIPTION
snmp version 1 is more safe - v2c don't work on MFC-5490CN. After switching to v1 seems to works fine:
```Data available: True
Model: MFC-5490CN
Firmware: U1005271959VER.E
Status: sleep mode
Serial no: BROC1F317401
Sensors data: {'status': 'sleep mode'}
```