### PR TITLE
Init `SnmpEngine` only once

### DIFF
--- a/brother/__init__.py
+++ b/brother/__init__.py
@@ -7,7 +7,6 @@ import re
 
 from pysnmp.error import PySnmpError
 import pysnmp.hlapi.asyncio as hlapi
-from pysnmp.hlapi.asyncore.cmdgen import lcd
 
 from .const import *
 

--- a/brother/__init__.py
+++ b/brother/__init__.py
@@ -12,6 +12,7 @@ from pysnmp.hlapi.asyncore.cmdgen import lcd
 from .const import *
 
 _LOGGER = logging.getLogger(__name__)
+_SNMP_ENGINE = hlapi.SnmpEngine()
 
 REGEX_MODEL_PATTERN = re.compile(r"MDL:(?P<model>[\w\-]+)")
 
@@ -130,11 +131,10 @@ class Brother:  # pylint:disable=too-many-instance-attributes
     async def _get_data(self):
         """Retreive data from printer."""
         raw_data = {}
-        snmp_engine = hlapi.SnmpEngine()
 
         try:
             request_args = [
-                snmp_engine,
+                _SNMP_ENGINE,
                 hlapi.CommunityData("public", mpModel=0),
                 hlapi.UdpTransportTarget(
                     (self._host, self._port), timeout=2, retries=10
@@ -144,8 +144,6 @@ class Brother:  # pylint:disable=too-many-instance-attributes
             errindication, errstatus, errindex, restable = await hlapi.getCmd(
                 *request_args, *self._oids
             )
-            # unconfigure SNMP engine
-            lcd.unconfigure(snmp_engine, None)
         except PySnmpError as error:
             self.data = {}
             raise ConnectionError(error)

--- a/brother/__init__.py
+++ b/brother/__init__.py
@@ -131,7 +131,7 @@ class Brother:  # pylint:disable=too-many-instance-attributes
     async def _get_data(self):
         """Retreive data from printer."""
         raw_data = {}
-        
+
         if not self._snmp_engine:
             self._snmp_engine = hlapi.SnmpEngine()
 

--- a/brother/__init__.py
+++ b/brother/__init__.py
@@ -147,7 +147,8 @@ class Brother:  # pylint:disable=too-many-instance-attributes
             errindication, errstatus, errindex, restable = await hlapi.getCmd(
                 *request_args, *self._oids
             )
-            lcd.unconfigure(self._snmp_engine)
+            # unconfigure SNMP engine
+            lcd.unconfigure(self._snmp_engine, None)
         except PySnmpError as error:
             self.data = {}
             raise ConnectionError(error)


### PR DESCRIPTION
This vastly improves performance of `_get_data()` for cases where device is unavailable.
This allows to get instantaneous response about device being unavailable,
since the init of engine is pretty complex operation likely due to need to parse MIB database.

On my device it takes around `140ms` to init the `hlapi.SnmpEngine()` object.
It seems ideal to only init it once, as it seems that we need to use around 40-50kB
for a single instance, and this instance appears that can be shared between all users.

Related to: https://github.com/home-assistant/core/issues/33866 