### PR TITLE
Migrate from `pysnmp` to `pysnmplib`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-pysnmp==4.4.12
-=======
 pysnmplib==5.0.10
->>>>>>> ddd53ad (Migrate from pysnmp to pysnmplib)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 pysnmp==4.4.12
+=======
+pysnmplib==5.0.10
+>>>>>>> ddd53ad (Migrate from pysnmp to pysnmplib)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements-test.txt", encoding="utf-8") as file:
 
 setup(
     name="brother",
-    version="1.1.0",
+    version="1.2.0",
     author="Maciej Bieniek",
     description="Python wrapper for getting data from Brother laser and inkjet \
         printers via SNMP.",


### PR DESCRIPTION
Fix Python 3.10 compatibility