### PR TITLE
Do not use `pysnmplib` 5.0.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 dacite
-pysnmplib
+pysnmplib<5.0.20

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 
 setup(
     name="brother",


### PR DESCRIPTION
`pysnmplib` 5.0.20 introduces a breaking change that requires more investigation for `brother` to work properly.

Related to https://github.com/bieniu/brother/issues/143